### PR TITLE
fix: ios safari wss connect fail (vite hmr)

### DIFF
--- a/src/hmr-sse-bridge.ts
+++ b/src/hmr-sse-bridge.ts
@@ -1,0 +1,244 @@
+import type { IncomingMessage, ServerResponse } from 'node:http'
+import type { ViteDevServer } from 'vite'
+
+const SSE_PATH = '/__hmr_sse'
+const SEND_PATH = '/__hmr_send'
+
+export function setupHmrSseBridge(server: ViteDevServer): void {
+  const sseClients = new Set<ServerResponse>()
+
+  // Monkey-patch server.ws.send to also push to SSE clients
+  const originalSend = server.ws.send.bind(server.ws)
+  server.ws.send = (...args: any[]) => {
+    // Call original WebSocket send
+    ;(originalSend as any)(...args)
+
+    // Build the payload string same as Vite does internally
+    let payload: string
+    if (typeof args[0] === 'string') {
+      // server.ws.send(event, data) — custom event, wrap it
+      payload = JSON.stringify({ type: 'custom', event: args[0], data: args[1] })
+    }
+    else {
+      // server.ws.send(payloadObject)
+      payload = JSON.stringify(args[0])
+    }
+
+    // Push to all SSE clients
+    for (const res of sseClients) {
+      res.write(`data: ${payload}\n\n`)
+    }
+  }
+
+  // Add middleware for SSE and POST endpoints
+  server.middlewares.use((req: IncomingMessage, res: ServerResponse, next: () => void) => {
+    const url = req.url?.split('?')[0]
+
+    if (url === SSE_PATH && req.method === 'GET') {
+      handleSseConnection(req, res, sseClients)
+      return
+    }
+
+    if (url === SEND_PATH && req.method === 'POST') {
+      handleClientMessage(req, res, server)
+      return
+    }
+
+    next()
+  })
+}
+
+function handleSseConnection(
+  _req: IncomingMessage,
+  res: ServerResponse,
+  sseClients: Set<ServerResponse>,
+): void {
+  res.writeHead(200, {
+    'Content-Type': 'text/event-stream',
+    'Cache-Control': 'no-cache',
+    'Connection': 'keep-alive',
+    'Access-Control-Allow-Origin': '*',
+  })
+
+  // Send initial connected message (same as Vite's WebSocket)
+  res.write(`data: ${JSON.stringify({ type: 'connected' })}\n\n`)
+
+  sseClients.add(res)
+
+  // Keep-alive ping every 30s
+  const keepAlive = setInterval(() => {
+    res.write(': ping\n\n')
+  }, 30000)
+
+  res.on('close', () => {
+    clearInterval(keepAlive)
+    sseClients.delete(res)
+  })
+}
+
+function handleClientMessage(
+  req: IncomingMessage,
+  res: ServerResponse,
+  server: ViteDevServer,
+): void {
+  let body = ''
+  req.on('data', (chunk: Buffer) => {
+    body += chunk.toString()
+  })
+  req.on('end', () => {
+    try {
+      const data = JSON.parse(body)
+      // Forward custom events to Vite's HMR server
+      // Vite client sends: { type: 'custom', event: string, data: any }
+      if (data.type === 'custom' && data.event) {
+        // Trigger listeners registered via server.ws.on(event, handler)
+        // by simulating the internal dispatch with a dummy client
+        const dummyClient = {
+          send: (...args: any[]) => { server.ws.send(...(args as [any])) },
+        }
+        // Access internal customListeners via the 'on' registered handlers
+        // We re-emit by calling the server's hot channel listener mechanism
+        ;(server as any).environments?.client?.hot?.api?.emit?.(data.event, data.data, dummyClient)
+      }
+      res.writeHead(200, {
+        'Content-Type': 'application/json',
+        'Access-Control-Allow-Origin': '*',
+      })
+      res.end('{"ok":true}')
+    }
+    catch {
+      res.writeHead(400)
+      res.end('{"ok":false}')
+    }
+  })
+}
+
+/**
+ * Client-side script that patches WebSocket to use SSE+fetch on iOS Safari.
+ * This script is injected via Vite's transformIndexHtml hook.
+ */
+export const hmrSseBridgeClientScript = `
+(function() {
+  // Activate when served over HTTPS to bypass WSS self-signed cert issues
+  if (location.protocol !== 'https:') return;
+
+  var OriginalWebSocket = window.WebSocket;
+
+  function SseWebSocket(originalUrl) {
+    var self = this;
+    // WebSocket readyState constants on instance
+    self.CONNECTING = 0;
+    self.OPEN = 1;
+    self.CLOSING = 2;
+    self.CLOSED = 3;
+    self.readyState = 0;
+    self.onopen = null;
+    self.onmessage = null;
+    self.onclose = null;
+    self.onerror = null;
+    self.bufferedAmount = 0;
+    self.extensions = '';
+    self.binaryType = 'blob';
+    self.protocol = 'vite-hmr';
+    self.url = originalUrl;
+    self._listeners = {};
+    self._opened = false;
+
+    var sseUrl = location.origin + '${SSE_PATH}';
+    var sendUrl = location.origin + '${SEND_PATH}';
+    self._sendUrl = sendUrl;
+
+    var es = new EventSource(sseUrl);
+    self._es = es;
+
+    es.onopen = function() {
+      if (self._opened) return;
+      self._opened = true;
+      self.readyState = 1;
+      var evt = new Event('open');
+      if (self.onopen) self.onopen(evt);
+      self._emit('open', evt);
+    };
+
+    es.onmessage = function(e) {
+      var evt = new MessageEvent('message', { data: e.data });
+      if (self.onmessage) self.onmessage(evt);
+      self._emit('message', evt);
+    };
+
+    es.onerror = function() {
+      // EventSource auto-reconnects on error; don't treat as fatal close
+      // Only emit error event, never close event (SSE handles reconnect internally)
+      if (self.readyState >= 2) return;
+      // EventSource auto-reconnects; no action needed
+    };
+  }
+
+  SseWebSocket.prototype.send = function(data) {
+    if (this.readyState !== 1) return;
+    fetch(this._sendUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: data
+    }).catch(function() {});
+  };
+
+  SseWebSocket.prototype.close = function() {
+    if (this.readyState >= 2) return;
+    this.readyState = 3;
+    if (this._es) this._es.close();
+    var evt = new CloseEvent('close', { code: 1000, reason: '', wasClean: true });
+    if (this.onclose) this.onclose(evt);
+    this._emit('close', evt);
+  };
+
+  SseWebSocket.prototype.addEventListener = function(type, fn, options) {
+    if (!this._listeners[type]) this._listeners[type] = [];
+    var entry = { fn: fn, once: !!(options && options.once) };
+    this._listeners[type].push(entry);
+  };
+
+  SseWebSocket.prototype.removeEventListener = function(type, fn) {
+    var list = this._listeners[type];
+    if (!list) return;
+    this._listeners[type] = list.filter(function(e) { return e.fn !== fn; });
+  };
+
+  SseWebSocket.prototype.dispatchEvent = function(evt) {
+    this._emit(evt.type, evt);
+    return true;
+  };
+
+  SseWebSocket.prototype._emit = function(type, evt) {
+    var list = this._listeners[type];
+    if (!list) return;
+    var remaining = [];
+    list.forEach(function(entry) {
+      entry.fn(evt);
+      if (!entry.once) remaining.push(entry);
+    });
+    this._listeners[type] = remaining;
+  };
+
+  function PatchedWebSocket(url, protocols) {
+    // Only intercept Vite HMR connections (protocol 'vite-hmr')
+    var isViteHmr = protocols === 'vite-hmr'
+      || (Array.isArray(protocols) && protocols.indexOf('vite-hmr') !== -1);
+    if (!isViteHmr) {
+      if (protocols !== undefined) {
+        return new OriginalWebSocket(url, protocols);
+      }
+      return new OriginalWebSocket(url);
+    }
+    return new SseWebSocket(url);
+  }
+
+  PatchedWebSocket.CONNECTING = 0;
+  PatchedWebSocket.OPEN = 1;
+  PatchedWebSocket.CLOSING = 2;
+  PatchedWebSocket.CLOSED = 3;
+  PatchedWebSocket.prototype = OriginalWebSocket.prototype;
+
+  window.WebSocket = PatchedWebSocket;
+})();
+`

--- a/src/hmr-sse-bridge.ts
+++ b/src/hmr-sse-bridge.ts
@@ -1,8 +1,10 @@
+import type { Buffer } from 'node:buffer'
 import type { IncomingMessage, ServerResponse } from 'node:http'
 import type { ViteDevServer } from 'vite'
 
 const SSE_PATH = '/__hmr_sse'
 const SEND_PATH = '/__hmr_send'
+const MAX_POST_BODY = 64 * 1024 // 64KB limit for client messages
 
 export function setupHmrSseBridge(server: ViteDevServer): void {
   const sseClients = new Set<ServerResponse>()
@@ -24,9 +26,14 @@ export function setupHmrSseBridge(server: ViteDevServer): void {
       payload = JSON.stringify(args[0])
     }
 
-    // Push to all SSE clients
+    // Push to all SSE clients (skip errored ones)
     for (const res of sseClients) {
-      res.write(`data: ${payload}\n\n`)
+      try {
+        res.write(`data: ${payload}\n\n`)
+      }
+      catch {
+        sseClients.delete(res)
+      }
     }
   }
 
@@ -57,7 +64,6 @@ function handleSseConnection(
     'Content-Type': 'text/event-stream',
     'Cache-Control': 'no-cache',
     'Connection': 'keep-alive',
-    'Access-Control-Allow-Origin': '*',
   })
 
   // Send initial connected message (same as Vite's WebSocket)
@@ -67,13 +73,19 @@ function handleSseConnection(
 
   // Keep-alive ping every 30s
   const keepAlive = setInterval(() => {
-    res.write(': ping\n\n')
+    try {
+      res.write(': ping\n\n')
+    }
+    catch { cleanup() }
   }, 30000)
 
-  res.on('close', () => {
+  function cleanup(): void {
     clearInterval(keepAlive)
     sseClients.delete(res)
-  })
+  }
+
+  res.on('close', cleanup)
+  res.on('error', cleanup)
 }
 
 function handleClientMessage(
@@ -82,10 +94,20 @@ function handleClientMessage(
   server: ViteDevServer,
 ): void {
   let body = ''
+  let overflow = false
   req.on('data', (chunk: Buffer) => {
     body += chunk.toString()
+    if (body.length > MAX_POST_BODY) {
+      overflow = true
+      req.destroy()
+    }
   })
   req.on('end', () => {
+    if (overflow) {
+      res.writeHead(413)
+      res.end('{"ok":false}')
+      return
+    }
     try {
       const data = JSON.parse(body)
       // Forward custom events to Vite's HMR server
@@ -102,7 +124,6 @@ function handleClientMessage(
       }
       res.writeHead(200, {
         'Content-Type': 'application/json',
-        'Access-Control-Allow-Origin': '*',
       })
       res.end('{"ok":true}')
     }
@@ -237,7 +258,8 @@ export const hmrSseBridgeClientScript = `
   PatchedWebSocket.OPEN = 1;
   PatchedWebSocket.CLOSING = 2;
   PatchedWebSocket.CLOSED = 3;
-  PatchedWebSocket.prototype = OriginalWebSocket.prototype;
+  PatchedWebSocket.prototype = Object.create(OriginalWebSocket.prototype);
+  PatchedWebSocket.prototype.constructor = PatchedWebSocket;
 
   window.WebSocket = PatchedWebSocket;
 })();

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,8 @@ let config: ResolvedConfig
 
 let caddy: CaddyInstant
 
+let hmrSseBridgeActive = false
+
 const cwd = process.cwd()
 
 function colorUrl(url: string): string {
@@ -124,11 +126,12 @@ export const unpluginFactory: UnpluginFactory<Options> = options => ({
       // Setup SSE bridge for iOS Safari WSS workaround
       if (options.https) {
         setupHmrSseBridge(server)
+        hmrSseBridgeActive = true
         consola.info('HMR SSE bridge enabled for iOS Safari WSS workaround')
       }
     },
     transformIndexHtml() {
-      if (config.command !== 'serve' || !options.https)
+      if (!hmrSseBridgeActive)
         return []
       // Inject client-side script to patch WebSocket on iOS Safari
       return [{

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import { Table } from 'console-table-printer'
 import c from 'picocolors'
 import { createUnplugin } from 'unplugin'
 import { CaddyInstant } from './caddy'
+import { hmrSseBridgeClientScript, setupHmrSseBridge } from './hmr-sse-bridge'
 import { consola, generateQrcode, getIpv4List, isAdmin, once } from './utils'
 
 let config: ResolvedConfig
@@ -119,6 +120,22 @@ export const unpluginFactory: UnpluginFactory<Options> = options => ({
       const base = server.config.base || '/'
 
       server.printUrls = () => vitePrintUrls(options, source, target, base, _printUrls)
+
+      // Setup SSE bridge for iOS Safari WSS workaround
+      if (options.https) {
+        setupHmrSseBridge(server)
+        consola.info('HMR SSE bridge enabled for iOS Safari WSS workaround')
+      }
+    },
+    transformIndexHtml() {
+      if (config.command !== 'serve' || !options.https)
+        return []
+      // Inject client-side script to patch WebSocket on iOS Safari
+      return [{
+        tag: 'script',
+        children: hmrSseBridgeClientScript,
+        injectTo: 'head-prepend',
+      }]
     },
   },
   webpack(compiler) {


### PR DESCRIPTION
# fix: iOS Safari WSS connect fail (Vite HMR) — SSE Bridge

Closes #5

## Problem

iOS Safari has a **confirmed WebKit bug** ([WebKit #145819](https://bugs.webkit.org/show_bug.cgi?id=145819)) where WebSocket Secure (WSS) connections reject self-signed certificates, even when the certificate has been fully trusted by the user on the device. HTTPS requests work normally with the same certificate — only WSS is affected.

This causes Vite's HMR (Hot Module Replacement) to fail completely on iOS Safari when accessing the dev server through the Caddy HTTPS reverse proxy, because Vite's HMR client uses `new WebSocket(url, 'vite-hmr')` to establish the connection.

```
Browser --HTTPS--> Caddy (self-signed TLS) --> Vite   ✅ Works
Browser --WSS----> Caddy (self-signed TLS) --> Vite   ❌ iOS Safari rejects
```

The error manifests as:
```
WebSocket network error: OSStatus Error -9807: Invalid certificate chain
```

## Root Cause Analysis

1. iOS Safari/WebKit uses a **separate certificate validation path** for WebSocket connections compared to regular HTTPS requests
2. Even with the root CA certificate installed and fully trusted (Settings → General → About → Certificate Trust Settings), WSS connections are still rejected
3. This bug has existed since at least 2015 and remains unfixed as of 2026
4. Apple engineers have acknowledged this as a bug internally (Radar `r. 25491679`)

In Vite 6+, when the WSS connection fails, `ws` stays `undefined` inside `createWebSocketModuleRunnerTransport`, but the error is silently swallowed. Any subsequent call to `ws!.send()` causes `TypeError: undefined is not an object`.

## Solution: SSE Bridge

Since iOS Safari trusts the self-signed certificate for regular HTTPS but not WSS, we bypass WebSocket entirely by bridging HMR through **Server-Sent Events (SSE) + fetch POST** — both of which use standard HTTPS.

### Architecture

```
                        HTTPS (trusted ✅)
iOS Safari  ──── GET  /__hmr_sse ────→  Caddy  ──→  Vite (SSE endpoint)
            ←─── SSE stream ────────────────────────  Server pushes HMR payloads

            ──── POST /__hmr_send ───→  Caddy  ──→  Vite (POST endpoint)
            ←─── JSON response ─────────────────────  Client sends HMR messages
```

### Implementation

Two parts:

**Server-side** (`src/hmr-sse-bridge.ts`):
- `GET /__hmr_sse` — SSE endpoint that streams HMR payloads to the browser
- `POST /__hmr_send` — Receives client-to-server HMR messages
- Monkey-patches `server.ws.send()` to simultaneously push payloads to all SSE clients

**Client-side** (injected via `transformIndexHtml`):
- Only activates on HTTPS pages (`location.protocol !== 'https:'`)
- Patches `window.WebSocket` constructor
- Intercepts Vite HMR connections (identified by `'vite-hmr'` protocol)
- Replaces them with `SseWebSocket` — a WebSocket-compatible shim backed by `EventSource` + `fetch`
- Non-HMR WebSocket connections are passed through to the original `WebSocket` untouched

### Key Design Decisions

1. **Protocol detection over UA sniffing**: Activates on all HTTPS pages instead of iOS Safari detection only, because the WSS+self-signed-cert issue also affects macOS Safari and other WebKit browsers
2. **EventSource error resilience**: SSE `onerror` events are intentionally not forwarded as WebSocket `close` events, because `EventSource` auto-reconnects — this prevents Vite's `connect()` from rejecting and leaving `ws` as `undefined`
3. **`{ once: true }` support**: Vite 6's `createWebSocketModuleRunnerTransport` uses `addEventListener('open', ..., { once: true })`, which the `SseWebSocket` shim fully supports
4. **Instance-level constants**: `SseWebSocket` exposes `CONNECTING/OPEN/CLOSING/CLOSED` as instance properties, matching Vite's `socket.readyState === socket.OPEN` pattern

## Scope

> **This fix currently only applies to Vite.** Webpack and Rspack are not affected by this change — their HMR mechanisms are different and require separate investigation.

## Files Changed

| File | Change |
|---|---|
| `src/hmr-sse-bridge.ts` | New file — SSE bridge server + client shim |
| `src/index.ts` | Import bridge, call `setupHmrSseBridge()` in `configureServer`, add `transformIndexHtml` hook |

---

# fix: iOS Safari WSS 连接失败 (Vite HMR) — SSE 桥接方案

关联 #5

## 问题

iOS Safari 存在一个**已确认的 WebKit bug**（[WebKit #145819](https://bugs.webkit.org/show_bug.cgi?id=145819)）：WebSocket Secure (WSS) 连接会拒绝自签名证书，即使用户已经在设备上完全信任了该证书。同一证书的 HTTPS 请求完全正常——只有 WSS 受影响。

这导致通过 Caddy HTTPS 反向代理访问 Vite 开发服务器时，HMR（热模块替换）在 iOS Safari 上完全失败，因为 Vite 的 HMR 客户端使用 `new WebSocket(url, 'vite-hmr')` 建立连接。

```
浏览器 --HTTPS--> Caddy（自签名 TLS）--> Vite   ✅ 正常
浏览器 --WSS----> Caddy（自签名 TLS）--> Vite   ❌ iOS Safari 拒绝
```

错误表现为：
```
WebSocket network error: OSStatus Error -9807: Invalid certificate chain
```

## 根因分析

1. iOS Safari/WebKit 对 WebSocket 连接使用了与普通 HTTPS 请求**不同的证书校验路径**
2. 即使在"设置 → 通用 → 关于本机 → 证书信任设置"中完全信任了根 CA 证书，WSS 连接仍然被拒绝
3. 此 bug 从 2015 年至今未修复（2026 年仍然存在）
4. Apple 工程师在内部已确认这是一个 bug（Radar `r. 25491679`）

在 Vite 6+ 中，WSS 连接失败后，`createWebSocketModuleRunnerTransport` 内部的 `ws` 变量保持 `undefined`，但错误被静默吞掉。后续任何 `ws!.send()` 调用都会导致 `TypeError: undefined is not an object`。

## 解决方案：SSE 桥接

既然 iOS Safari 信任自签名证书的 HTTPS 但不信任 WSS，我们完全绕过 WebSocket，通过 **SSE（Server-Sent Events）+ fetch POST** 来桥接 HMR——两者都使用标准 HTTPS。

### 架构

```
                        HTTPS（受信任 ✅）
iOS Safari  ──── GET  /__hmr_sse ────→  Caddy  ──→  Vite（SSE 端点）
            ←─── SSE 流 ────────────────────────────  服务器推送 HMR 数据

            ──── POST /__hmr_send ───→  Caddy  ──→  Vite（POST 端点）
            ←─── JSON 响应 ─────────────────────────  客户端发送 HMR 消息
```

### 实现

分为两部分：

**服务端**（`src/hmr-sse-bridge.ts`）：
- `GET /__hmr_sse` — SSE 端点，将 HMR 数据以流的形式推送给浏览器
- `POST /__hmr_send` — 接收客户端到服务端的 HMR 消息
- Monkey-patch `server.ws.send()`，在 WebSocket 广播的同时将数据推送给所有 SSE 客户端

**客户端**（通过 `transformIndexHtml` 注入）：
- 仅在 HTTPS 页面激活（`location.protocol !== 'https:'` 时跳过）
- Patch `window.WebSocket` 构造函数
- 拦截 Vite HMR 连接（通过 `'vite-hmr'` 协议识别）
- 替换为 `SseWebSocket` —— 一个基于 `EventSource` + `fetch` 的 WebSocket 兼容垫片
- 非 HMR 的 WebSocket 连接不受影响，透传给原始 `WebSocket`

### 关键设计决策

1. **协议检测而非 UA 嗅探**：在所有 HTTPS 页面上激活，而不仅限于 iOS Safari，因为 WSS + 自签名证书的问题同样影响 macOS Safari 和其他 WebKit 浏览器
2. **EventSource 错误容错**：SSE 的 `onerror` 事件不会被转发为 WebSocket 的 `close` 事件，因为 `EventSource` 会自动重连——这避免了 Vite 的 `connect()` reject 导致 `ws` 保持 `undefined`
3. **支持 `{ once: true }`**：Vite 6 的 `createWebSocketModuleRunnerTransport` 使用 `addEventListener('open', ..., { once: true })`，`SseWebSocket` 垫片完整支持
4. **实例级常量**：`SseWebSocket` 在实例上暴露 `CONNECTING/OPEN/CLOSING/CLOSED` 属性，匹配 Vite 的 `socket.readyState === socket.OPEN` 检查模式

## 适用范围

> **此修复目前仅适用于 Vite。** Webpack 和 Rspack 不受此变更影响——它们的 HMR 机制不同，需要单独调研。

## 变更文件

| 文件 | 变更 |
|---|---|
| `src/hmr-sse-bridge.ts` | 新文件 — SSE 桥接服务端 + 客户端垫片 |
| `src/index.ts` | 导入桥接模块，在 `configureServer` 中调用 `setupHmrSseBridge()`，添加 `transformIndexHtml` 钩子 |
